### PR TITLE
Update docs on how to run the proxy locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ An ephemeral memory store backend can be used for faster feedback testing when p
 ## Running Locally
 
 1. Compile binary: `make eigenda-proxy`
-2. Run binary; e.g: `./bin/eigenda-proxy --addr 127.0.0.1 --port 5050 --eigenda-rpc 127.0.0.1:443 --eigenda-status-query-timeout 45m --eigenda-g1-path e2e/resources/kzg/g1.point --eigenda-g2-tau-path e2e/resources/kzg/g2.point.powerOf2 --eigenda-use-tls true`
+2. Generate a new private key and save it as `EIGENDA_PROXY_SIGNER_PRIVATE_KEY_HEX` env var without the `0x` prefix.
+3. Run binary; e.g: `./bin/eigenda-proxy --addr 127.0.0.1 --port 5050 --eigenda-rpc 127.0.0.1:443 --eigenda-status-query-timeout 45m --eigenda-g1-path e2e/resources/kzg/g1.point --eigenda-g2-tau-path e2e/resources/kzg/g2.point.powerOf2 --eigenda-max-blob-length='90Kib'`
 
 **Env File**
 An env file can be provided to the binary for runtime process ingestion; e.g:


### PR DESCRIPTION
- The previous version of the docs used a parameter (`eigenda-use-tls`) that wasn't longer available.
- Specifying a valid `eigenda-max-blob-length` is necessary. Otherwise an error is thrown:
```
INFO [06-18|16:04:11.833] Initializing EigenDA proxy server...     role=eigenda_proxy
INFO [06-18|16:04:11.834] Using eigenda backend                    role=eigenda_proxy
INFO [06-18|16:04:11.836] failed to read G1 points cannot read file unexpected EOF role=eigenda_proxy
CRIT [06-18|16:04:11.836] Application failed                       role=eigenda_proxy message="failed to create store: cannot read file unexpected EOF"

```